### PR TITLE
Update DynamicAtlas.as

### DIFF
--- a/dynamicTextureAtlasGenerator/src/com/emibap/textureAtlas/DynamicAtlas.as
+++ b/dynamicTextureAtlasGenerator/src/com/emibap/textureAtlas/DynamicAtlas.as
@@ -199,6 +199,7 @@ package com.emibap.textureAtlas
 				
 				tmpBData = new BitmapData(realBounds.width, realBounds.height, false);
 				filterRect = tmpBData.generateFilterRect(tmpBData.rect, clipFilters[j]);
+				realBounds = realBounds.union(filterRect);
 				tmpBData.dispose();
 				
 				while (++j < clipFiltersLength)


### PR DESCRIPTION
hi, I found DynamicAtlas's method getRealBounds has a issue
if displayobject has only a filter, the return bounds is incorrect
